### PR TITLE
Fix src-url to target from PyPI

### DIFF
--- a/rever.xsh
+++ b/rever.xsh
@@ -17,3 +17,4 @@ $VERSION_BUMP_PATTERNS = [  # These note where/how to find the version numbers
 
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
+$CONDA_FORGE_SOURCE_URL = 'https://pypi.io/packages/source/a/arxiv-collector/arxiv-collector-$VERSION.tar.gz'


### PR DESCRIPTION
This should fix https://github.com/regro/rever/issues/173

We could also improve rever to do better than the current default value.